### PR TITLE
Fix deprecations on PHP 8.1

### DIFF
--- a/Container.php
+++ b/Container.php
@@ -79,7 +79,7 @@ class Container implements \ArrayAccess, ContainerInterface
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return $this->has($key);
     }
@@ -91,6 +91,7 @@ class Container implements \ArrayAccess, ContainerInterface
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -102,7 +103,7 @@ class Container implements \ArrayAccess, ContainerInterface
      * @param string $key
      * @param mixed  $value
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->register($key, $value);
     }
@@ -112,7 +113,7 @@ class Container implements \ArrayAccess, ContainerInterface
      *
      * @param string $key
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->definitions[$key], $this->instances[$key]);
     }


### PR DESCRIPTION
I am trying out various DI container libraries as a replacement for unmaintained Dice and I really like your so far.

Unfortunately, on PHP 8.1, it produces annoying deprecation warnings:

    Deprecated: Return type of Slince\Di\Container::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Container.php on line 82
    Deprecated: Return type of Slince\Di\Container::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Container.php on line 94
    Deprecated: Return type of Slince\Di\Container::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Container.php on line 105
    Deprecated: Return type of Slince\Di\Container::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Container.php on line 115

Let’s fix that by adding return typehints to the methods except for `offsetGet`, since the `mixed` type hint is only available since PHP 8.0.0.
We will silence the `offsetGet` warning using the attribute for now.

I can add type hints elsewhere as well, if you want. And port the CI to GitHub actions, now that Travis is dead. And also add static analysis to CI.
