### PR TITLE
Support psr/container 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.4",
         "dflydev/dot-access-data": "^3.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.0|^9.0"


### PR DESCRIPTION
It adds `bool` as a return type hint to `has` method.
We already have this so we can support both versions.
