### PR TITLE
tests: Fix implicit nullability warning

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -204,7 +204,7 @@ class ContainerTest extends TestCase
     public function testGetWithMissingOptionalClassDependency()
     {
         $container = new Container();
-        $container->register('director', function ($name, $age, ActorInterface $actor = null) {
+        $container->register('director', function ($name, $age, ?ActorInterface $actor = null) {
             $this->assertNull($actor);
 
             return new Director($name, $age);

--- a/Tests/TestClass/Actor.php
+++ b/Tests/TestClass/Actor.php
@@ -6,7 +6,7 @@ class Actor implements ActorInterface
 {
     private $birthday;
 
-    public function __construct(Foo $foo = null, ?\DateTime $birthday = null)
+    public function __construct(?Foo $foo = null, ?\DateTime $birthday = null)
     {
         $this->birthday = $birthday;
     }


### PR DESCRIPTION
PHP 8.4 deprecated defaulting arguments to null without it being reflected in the type hint:

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This would trigger a warning when running tests:

    Deprecated: Slince\Di\Tests\TestClass\Actor::__construct(): Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead
